### PR TITLE
Also export @Deprecated decorator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './decorators/deprecated';
 export * from './decorators/example';
 export * from './decorators/parameter';
 export * from './decorators/methods';


### PR DESCRIPTION
@Deprecated is not really usable without exporting it


